### PR TITLE
v1.1: Power & switches support, improved menu classification, settings tabs

### DIFF
--- a/HomeMenuBar.xcodeproj/project.pbxproj
+++ b/HomeMenuBar.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.developer.HomeMenuBarApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -576,7 +576,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.developer.HomeMenuBarApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/HomeMenuBar/BaseManager+mac2iOS.swift
+++ b/HomeMenuBar/BaseManager+mac2iOS.swift
@@ -8,6 +8,9 @@ extension BaseManager {
         homeManager?.delegate = nil
         homeManager = HMHomeManager()
         homeManager?.delegate = self
+        // Reset loading state so early alerts are not shown
+        initialHomeListReceived = false
+        homeFetchRetryCount = 0
     }
 
     /// Read a characteristic value and forward the result to the macOS plug‑in.

--- a/Shared/DeviceStateManager.swift
+++ b/Shared/DeviceStateManager.swift
@@ -77,6 +77,25 @@ import Foundation
                 if let doubleValue = value as? Double {
                     deviceState.currentRelativeHumidity = doubleValue // %
                 }
+            case .batteryLevel:
+                if let doubleValue = value as? Double { deviceState.batteryLevel = doubleValue }
+            case .chargingState:
+                if let intValue = value as? Int { deviceState.isCharging = (intValue != 0) }
+                else if let boolValue = value as? Bool { deviceState.isCharging = boolValue }
+            case .contactState:
+                if let boolValue = value as? Bool { deviceState.isContactDetected = boolValue }
+            case .outletInUse:
+                if let boolValue = value as? Bool { deviceState.isOutletInUse = boolValue }
+            case .statusLowBattery:
+                if let boolValue = value as? Bool { deviceState.isLowBattery = boolValue }
+            case .outputState:
+                if let boolValue = value as? Bool { deviceState.programmableSwitchOutputOn = boolValue }
+            case .inputEvent:
+                if let intValue = value as? Int { deviceState.lastInputEvent = intValue }
+                else if let doubleValue = value as? Double { deviceState.lastInputEvent = Int(doubleValue) }
+            case .powerModeSelection:
+                if let intValue = value as? Int { deviceState.powerModeSelection = intValue }
+                else if let doubleValue = value as? Double { deviceState.powerModeSelection = Int(doubleValue) }
             default:
                 break
             }
@@ -178,6 +197,15 @@ import Foundation
     public var currentTemperature: Double = 0.0
     public var currentRelativeHumidity: Double = 0.0
     public var isReachable: Bool = true
+    // Power and switches
+    public var batteryLevel: Double = 0.0
+    public var isCharging: Bool = false
+    public var isContactDetected: Bool = false
+    public var isOutletInUse: Bool = false
+    public var isLowBattery: Bool = false
+    public var programmableSwitchOutputOn: Bool = false
+    public var lastInputEvent: Int = 0
+    public var powerModeSelection: Int = 0
     
     public init(deviceUUID: UUID) {
         self.deviceUUID = deviceUUID
@@ -185,7 +213,7 @@ import Foundation
     }
     
     public override var description: String {
-        return "DeviceState(deviceUUID: \(deviceUUID), isOn: \(isOn), brightness: \(brightness), hue: \(hue), saturation: \(saturation), colorTemperature: \(colorTemperature), currentLightLevel: \(currentLightLevel), isReachable: \(isReachable))"
+        return "DeviceState(deviceUUID: \(deviceUUID), isOn: \(isOn), brightness: \(brightness), hue: \(hue), saturation: \(saturation), colorTemperature: \(colorTemperature), currentLightLevel: \(currentLightLevel), currentTemperature: \(currentTemperature), currentRelativeHumidity: \(currentRelativeHumidity), batteryLevel: \(batteryLevel), isCharging: \(isCharging), isContactDetected: \(isContactDetected), isOutletInUse: \(isOutletInUse), isLowBattery: \(isLowBattery), programmableSwitchOutputOn: \(programmableSwitchOutputOn), lastInputEvent: \(lastInputEvent), powerModeSelection: \(powerModeSelection), isReachable: \(isReachable))"
     }
 }
 

--- a/Shared/SharedTypes.swift
+++ b/Shared/SharedTypes.swift
@@ -60,6 +60,7 @@ public enum ServiceType: String, CaseIterable {
     case lightbulb = "lightbulb"
     case `switch` = "switch"
     case outlet = "outlet"
+    case programmableSwitch = "programmableSwitch"
     
     public var isSupported: Bool {
         switch self {
@@ -67,7 +68,10 @@ public enum ServiceType: String, CaseIterable {
              .humiditySensor,
              .temperatureSensor,
              .lightSensor,
-             .airQualitySensor:
+             .airQualitySensor,
+             .switch,
+             .outlet,
+             .programmableSwitch:
             return true
         default:
             return false
@@ -106,10 +110,21 @@ public enum ServiceType: String, CaseIterable {
     case sulphurDioxideDensity = 25
     case vocDensity = 26
     
+    // Power and switches
+    case batteryLevel = 27
+    case chargingState = 28
+    case contactState = 29
+    case outletInUse = 30
+    case statusLowBattery = 31
+    case outputState = 32
+    case inputEvent = 33
+    case powerModeSelection = 34
+    
     public var isSupported: Bool {
         switch self {
         case .brightness, .hue, .saturation, .currentTemperature, .currentRelativeHumidity, .on, .targetTemperature, .targetRelativeHumidity, .currentLightLevel, .colorTemperature,
-             .airQuality, .airParticulateDensity, .airParticulateSize, .smokeDetected, .carbonDioxideDetected, .carbonDioxideLevel, .carbonDioxidePeakLevel, .carbonMonoxideDetected, .carbonMonoxideLevel, .carbonMonoxidePeakLevel, .nitrogenDioxideDensity, .ozoneDensity, .pm10Density, .pm2_5Density, .sulphurDioxideDensity, .vocDensity:
+             .airQuality, .airParticulateDensity, .airParticulateSize, .smokeDetected, .carbonDioxideDetected, .carbonDioxideLevel, .carbonDioxidePeakLevel, .carbonMonoxideDetected, .carbonMonoxideLevel, .carbonMonoxidePeakLevel, .nitrogenDioxideDensity, .ozoneDensity, .pm10Density, .pm2_5Density, .sulphurDioxideDensity, .vocDensity,
+             .batteryLevel, .chargingState, .contactState, .outletInUse, .statusLowBattery, .outputState, .inputEvent, .powerModeSelection:
             return true
         default:
             return false
@@ -145,6 +160,14 @@ public enum ServiceType: String, CaseIterable {
         case .pm2_5Density: return "pm2_5Density"
         case .sulphurDioxideDensity: return "sulphurDioxideDensity"
         case .vocDensity: return "vocDensity"
+        case .batteryLevel: return "batteryLevel"
+        case .chargingState: return "chargingState"
+        case .contactState: return "contactState"
+        case .outletInUse: return "outletInUse"
+        case .statusLowBattery: return "statusLowBattery"
+        case .outputState: return "outputState"
+        case .inputEvent: return "inputEvent"
+        case .powerModeSelection: return "powerModeSelection"
         }
     }
 }
@@ -441,6 +464,9 @@ extension ServiceType {
             self = .switch
         case HMServiceTypeOutlet:
             self = .outlet
+        // Stateless/programmable switch support
+        case HMServiceTypeStatelessProgrammableSwitch:
+            self = .programmableSwitch
         default:
             self = .unknown
         }
@@ -449,6 +475,14 @@ extension ServiceType {
 
 extension CharacteristicType {
     init(key: String) {
+        // Handle newer characteristics that require availability checks first
+        if #available(iOS 18.0, macCatalyst 18.0, *) {
+            if key == HMCharacteristicTypePowerModeSelection {
+                self = .powerModeSelection
+                return
+            }
+        }
+        
         switch key {
         case HMCharacteristicTypeBrightness:
             self = .brightness
@@ -504,6 +538,22 @@ extension CharacteristicType {
             self = .sulphurDioxideDensity
         case HMCharacteristicTypeVolatileOrganicCompoundDensity:
             self = .vocDensity
+        
+        // Power and switches
+        case HMCharacteristicTypeBatteryLevel:
+            self = .batteryLevel
+        case HMCharacteristicTypeChargingState:
+            self = .chargingState
+        case HMCharacteristicTypeContactState:
+            self = .contactState
+        case HMCharacteristicTypeOutletInUse:
+            self = .outletInUse
+        case HMCharacteristicTypeStatusLowBattery:
+            self = .statusLowBattery
+        case HMCharacteristicTypeOutputState:
+            self = .outputState
+        case HMCharacteristicTypeInputEvent:
+            self = .inputEvent
             
         default:
             self = .unknown

--- a/macOSBridge/NSMenuItem+HomeMenu.swift
+++ b/macOSBridge/NSMenuItem+HomeMenu.swift
@@ -61,9 +61,14 @@ extension NSMenuItem {
         case .lightbulb:
             return [AdaptiveLightbulbMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]
         case .switch:
+            HMLog.menuDebug("Factory: routing service \(serviceInfo.name) to SwitchMenuItem (explicit type)")
             return [SwitchMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]
         case .outlet:
+            HMLog.menuDebug("Factory: routing service \(serviceInfo.name) to OutletMenuItem (explicit type)")
             return [OutletMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]
+        case .programmableSwitch:
+            HMLog.menuDebug("Factory: routing service \(serviceInfo.name) to ProgrammableSwitchMenuItem (explicit type)")
+            return [ProgrammableSwitchMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]
         case .unknown:
             // Fallback routing for unknown types using characteristics, then weak name hints
             if hasAirQualityCharacteristics {
@@ -75,7 +80,14 @@ extension NSMenuItem {
             if hasColorCharacteristics || (hasOnOff && nameSuggestsLightbulb) {
                 return [AdaptiveLightbulbMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]
             }
-            if nameSuggestsSwitch {
+            // Prefer outlet UI if an outlet-in-use characteristic is present
+            if serviceInfo.characteristics.contains(where: { $0.type == .outletInUse }) {
+                HMLog.menuDebug("Factory: routing service \(serviceInfo.name) to OutletMenuItem (fallback by outletInUse)")
+                return [OutletMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]
+            }
+            // Then prefer explicit switch if we saw any on/off characteristic or name suggests
+            if hasOnOff || nameSuggestsSwitch {
+                HMLog.menuDebug("Factory: routing service \(serviceInfo.name) to SwitchMenuItem (fallback)")
                 return [SwitchMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]
             }
             return [ToggleMenuItem(serviceInfo: serviceInfo, mac2ios: mac2ios)]

--- a/macOSBridge/PrincipalClass.swift
+++ b/macOSBridge/PrincipalClass.swift
@@ -680,8 +680,8 @@ public class MacOSController: NSObject, @preconcurrency iOS2Mac, NSMenuDelegate 
                 var sensorItems: [NSMenuItem] = []
 
                 for accessory in roomAccessories {
-                    // Collect device services
-                    let deviceServices = accessory.services.filter { isServiceSupported($0) && isDeviceService($0) && !isDeviceHidden($0.uniqueIdentifier.uuidString) }
+                    // Collect device services (infer type before support gating)
+                    let deviceServices = accessory.services.filter { isDeviceService($0) && !isDeviceHidden($0.uniqueIdentifier.uuidString) }
                     for svc in deviceServices {
                         let created = NSMenuItem.HomeMenus(serviceInfo: svc, mac2ios: iosListener).compactMap { $0 }
                         deviceItems.append(contentsOf: created)
@@ -702,7 +702,7 @@ public class MacOSController: NSObject, @preconcurrency iOS2Mac, NSMenuDelegate 
                     for svc in accessory.services {
                         HMLog.menuDebug("Room \(room.name): Service \(svc.name) - isServiceSupported: \(isServiceSupported(svc)), isSensorService: \(isSensorService(svc)), isHidden: \(isDeviceHidden(svc.uniqueIdentifier.uuidString))")
                     }
-                    let sensorServices = accessory.services.filter { isServiceSupported($0) && isSensorService($0) && !isDeviceHidden($0.uniqueIdentifier.uuidString) }
+                    let sensorServices = accessory.services.filter { isSensorService($0) && !isDeviceHidden($0.uniqueIdentifier.uuidString) }
                     HMLog.menuDebug("Room \(room.name): Found \(sensorServices.count) sensor services for accessory \(accessory.name)")
                     for svc in sensorServices {
                         HMLog.menuDebug("Processing sensor service: \(svc.name) (UUID: \(svc.uniqueIdentifier))")
@@ -774,7 +774,7 @@ public class MacOSController: NSObject, @preconcurrency iOS2Mac, NSMenuDelegate 
 
             for accessory in accessories {
                 for svc in accessory.services {
-                    guard isServiceSupported(svc), !isDeviceHidden(svc.uniqueIdentifier.uuidString) else { continue }
+                    guard !isDeviceHidden(svc.uniqueIdentifier.uuidString) else { continue }
                     if isDeviceService(svc) {
                         let created = NSMenuItem.HomeMenus(serviceInfo: svc, mac2ios: iosListener).compactMap { $0 }
                         deviceItems.append(contentsOf: created)


### PR DESCRIPTION
- Added support for switches, outlets, and programmable switches
- New power-related characteristics (battery, charging, outlet in use, etc.)
- Fixed state tracking to service UUIDs
- Menu routing improvements; outlet and switch icons
- Settings window now with Home / Scenes / Help tabs
- Home tab groups devices into Bulbs, Power & Outlets, Sensors
- Help includes GitHub repo link and app version
- Bug fixes for first-run homes and settings hide/show indexing